### PR TITLE
Anonymise contacts

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
@@ -1,38 +1,32 @@
-//=============================================================================
-//===
-//=== SchemaManager
-//===
-//=============================================================================
-//=== Copyright (C) 2001-2011 Food and Agriculture Organization of the
-//=== United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//=== and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.guiservices.XmlFile;
 import jeeves.server.overrides.ConfigurationOverrides;
-
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
@@ -45,6 +39,7 @@ import org.fao.geonet.exceptions.NoSchemaMatchesException;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.exceptions.SchemaMatchConflictException;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.schema.SchemaLoader;
 import org.fao.geonet.kernel.schema.SchemaPlugin;
 import org.fao.geonet.kernel.setting.SettingInfo;
@@ -60,13 +55,7 @@ import org.springframework.context.ApplicationContext;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -96,8 +85,8 @@ public class SchemaManager {
      * Active writers count
      */
     private static int activeWriters = 0;
-    private Map<String, Schema> hmSchemas = new HashMap<String, Schema>();
-    private Map<String, Namespace> hmSchemasTypenames = new HashMap<String, Namespace>();
+    private Map<String, Schema> hmSchemas = new HashMap<>();
+    private Map<String, Namespace> hmSchemasTypenames = new HashMap<>();
     private String[] fnames = {"labels.xml", "codelists.xml", "strings.xml"};
     private Path schemaPluginsDir;
     private Path schemaPluginsCat;
@@ -277,7 +266,7 @@ public class SchemaManager {
      */
     public Set<String> getDependencies(String name) {
 
-        Set<String> dependencies = new HashSet<String>();
+        Set<String> dependencies = new HashSet<>();
 
         beforeRead();
         try {
@@ -530,7 +519,7 @@ public class SchemaManager {
         try {
             Schema schema = hmSchemas.get(name);
             List<Element> childs = schema.getConversionElements();
-            List<Element> dChilds = new ArrayList<Element>();
+            List<Element> dChilds = new ArrayList<>();
             for (Element child : childs) {
                 if (child != null) dChilds.add((Element) child.clone());
             }
@@ -858,7 +847,7 @@ public class SchemaManager {
         if (schema != null) {
             if (doDependencies) {
                 List<String> dependsOnMe = getSchemasThatDependOnMe(name);
-                if (dependsOnMe.size() > 0) {
+                if (!dependsOnMe.isEmpty()) {
                     String errStr = "Cannot remove schema " + name + " because the following schemas list it as a dependency: " + dependsOnMe;
                     Log.error(Geonet.SCHEMA_MANAGER, errStr);
                     throw new OperationAbortedEx(errStr);
@@ -948,7 +937,7 @@ public class SchemaManager {
 
         final String schemaName = schemaDir.getFileName().toString();
         Path locBase = schemaDir.resolve("loc");
-        Map<String, XmlFile> xfMap = new HashMap<String, XmlFile>();
+        Map<String, XmlFile> xfMap = new HashMap<>();
 
         for (String fname : fnames) {
             Path filePath = path.resolve("loc").resolve(defaultLang).resolve(fname);
@@ -1307,7 +1296,7 @@ public class SchemaManager {
      * Check dependencies for all schemas - remove those that fail.
      */
     private void checkDependencies(Element schemaPluginCatRoot) throws Exception {
-        List<String> removes = new ArrayList<String>();
+        List<String> removes = new ArrayList<>();
 
         // process each schema to see whether its dependencies are present
         for (String schemaName : hmSchemas.keySet()) {
@@ -1330,7 +1319,7 @@ public class SchemaManager {
     }
 
     private void checkAppSupported(Element schemaPluginCatRoot) throws Exception {
-        List<String> removes = new ArrayList<String>();
+        List<String> removes = new ArrayList<>();
 
         final SystemInfo systemInfo = ApplicationContextHolder.get().getBean(SystemInfo.class);
 
@@ -1385,7 +1374,7 @@ public class SchemaManager {
      */
     public List<String> getSchemasThatDependOnMe(String schemaName) {
 
-        List<String> myDepends = new ArrayList<String>();
+        List<String> myDepends = new ArrayList<>();
 
         // process each schema to see whether its dependencies are present
         for (String schemaNameToTest : hmSchemas.keySet()) {
@@ -1433,7 +1422,7 @@ public class SchemaManager {
 
         // get list of depends elements from schema-ident.xml
         List<Element> dependsList = root.getChildren("depends", GEONET_SCHEMA_NS);
-        if (dependsList.size() == 0) {
+        if (dependsList.isEmpty()) {
             dependsList = root.getChildren("depends", GEONET_SCHEMA_PREFIX_NS);
         }
         return dependsList;
@@ -1491,11 +1480,11 @@ public class SchemaManager {
      * true if schema requires to synch the uuid column schema info with the uuid in the metadata
      * record (updated on editing or in UFO).
      */
-    private Map<String, Pair<String, Element>> extractOperationFilters(Path xmlIdFile) throws Exception {
+    private Map<String, MetadataSchemaOperationFilter> extractOperationFilters(Path xmlIdFile) throws Exception {
         Element root = Xml.loadFile(xmlIdFile);
         Element filters = root.getChild("filters", GEONET_SCHEMA_NS);
-        Map<String, Pair<String, Element>> filterRules =
-            new HashMap<String, Pair<String, Element>>();
+        Map<String, MetadataSchemaOperationFilter> filterRules =
+            new HashMap<>();
         if (filters == null) {
             return filterRules;
         } else {
@@ -1507,7 +1496,8 @@ public class SchemaManager {
                     Element markedElement = ruleElement.getChild("keepMarkedElement", GEONET_SCHEMA_NS);
                     if (StringUtils.isNotBlank(ifNotOperation) &&
                         StringUtils.isNotBlank(xpath)) {
-                        filterRules.put(ifNotOperation, Pair.read(xpath, markedElement));
+                        MetadataSchemaOperationFilter filter = new MetadataSchemaOperationFilter(xpath, ifNotOperation, markedElement);
+                        filterRules.put(ifNotOperation, filter);
                     }
                 }
             }
@@ -1563,13 +1553,14 @@ public class SchemaManager {
         if (!Files.exists(xmlConvFile)) {
             if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
                 Log.debug(Geonet.SCHEMA_MANAGER, "Schema conversions file not present");
-            return new ArrayList<Element>();
+            return new ArrayList<>();
         } else {
             Element root = Xml.loadFile(xmlConvFile);
             ConfigurationOverrides.DEFAULT.updateWithOverrides(xmlConvFile.toString(), null, basePath, root);
 
-            if (root.getName() != "conversions")
+            if (!root.getName().equals("conversions")) {
                 throw new IllegalArgumentException("Schema conversions file " + xmlConvFile + " is invalid, no <conversions> root element");
+            }
             @SuppressWarnings("unchecked")
             List<Element> result = root.getChildren();
             return result;
@@ -1620,7 +1611,7 @@ public class SchemaManager {
                 Attribute type = elem.getAttribute("type");
 
                 // --- try and find the attribute and value in md
-                if (mode == MODE_ATTRIBUTEWITHVALUE && elem.getName() == "attributes") {
+                if (mode == MODE_ATTRIBUTEWITHVALUE && elem.getName().equals("attributes")) {
                     @SuppressWarnings("unchecked")
                     List<Attribute> atts = elem.getAttributes();
                     for (Attribute searchAtt : atts) {
@@ -1914,7 +1905,6 @@ public class SchemaManager {
         List<String> listOfTypenames = new ArrayList<>();
         while (iterator.hasNext()) {
             String typeName = iterator.next();
-            Namespace ns = hmSchemasTypenames.get(typeName);
             listOfTypenames.add(typeName);
         }
         return listOfTypenames;

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
@@ -1,41 +1,39 @@
-//=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel;
 
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-
+import jeeves.server.context.ServiceContext;
+import jeeves.xlink.Processor;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Pair;
-import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperation;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.utils.Log;
@@ -45,15 +43,16 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
 
-import jeeves.server.context.ServiceContext;
-import jeeves.xlink.Processor;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * This class is responsible of reading and writing xml on the database. It works on tables like
+ * This class is responsible for reading and writing xml on the database. It works on tables like
  * (id, data, lastChangeDate).
  */
 public abstract class XmlSerializer {
-    private static InheritableThreadLocal<ThreadLocalConfiguration> configThreadLocal = new InheritableThreadLocal<XmlSerializer.ThreadLocalConfiguration>();
+    private static final InheritableThreadLocal<ThreadLocalConfiguration> configThreadLocal = new InheritableThreadLocal<>();
 
     public static ThreadLocalConfiguration getThreadLocal(boolean setIfNotPresent) {
         ThreadLocalConfiguration config = configThreadLocal.get();
@@ -69,17 +68,24 @@ public abstract class XmlSerializer {
         configThreadLocal.set(null);
     }
 
+    /**
+     * Removed the specified XML elements from the passed documents.
+     * @param metadata original metadata. At the end of the process it won't contain the filtered elements.
+     * @param filter elements to remove depending on the operation done.
+     * @param namespaces list of the document namespaces.
+     * @throws JDOMException if any problem modifying the DOM occurs.
+     */
     public static void removeFilteredElement(Element metadata,
-                                             final Pair<String, Element> xPathAndMarkedElement,
+                                             final MetadataSchemaOperationFilter filter,
                                              List<Namespace> namespaces) throws JDOMException {
         // xPathAndMarkedElement seem can be null in some schemas like dublin core
-        if (xPathAndMarkedElement == null) return;
+        if (filter == null) return;
 
-        String xpath = xPathAndMarkedElement.one();
-        Element mark = xPathAndMarkedElement.two();
+        String xpathFilter = filter.getXpath();
+        Element mark = filter.getMarkedElement();
 
         List<?> nodes = Xml.selectNodes(metadata,
-            xpath,
+            xpathFilter,
             namespaces);
         for (Object object : nodes) {
             if (object instanceof Element) {
@@ -89,8 +95,8 @@ public abstract class XmlSerializer {
 
                     // Remove attributes
                     @SuppressWarnings("unchecked")
-                    List<Attribute> atts = new ArrayList<Attribute>(element.getAttributes());
-                    for (Attribute attribute : atts) {
+                    List<Attribute> attributesList = new ArrayList<Attribute>(element.getAttributes());
+                    for (Attribute attribute : attributesList) {
                         attribute.detach();
                     }
 
@@ -182,33 +188,42 @@ public abstract class XmlSerializer {
             // Check if a filter is defined for this schema
             // for the editing operation ie. user who can not edit
             // will not see those elements.
-            Pair<String, Element> editXpathFilter = mds.getOperationFilter(ReservedOperation.editing);
-            boolean filterEditOperationElements = editXpathFilter != null;
+            MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(MetadataSchemaOperation.editing);
+            boolean filterEditOperationElements = editFilter != null;
             List<Namespace> namespaces = mds.getNamespaces();
             if (context != null) {
-                if (editXpathFilter != null) {
+                if (editFilter != null) {
                     boolean canEdit = accessManager.canEdit(context, id);
                     if (canEdit) {
                         filterEditOperationElements = false;
                     }
                 }
-                Pair<String, Element> downloadXpathFilter = mds.getOperationFilter(ReservedOperation.download);
-                if (downloadXpathFilter != null) {
-                    boolean canDownload = accessManager.canDownload(context, id);
-                    if (!canDownload) {
-                        removeFilteredElement(metadataXml, downloadXpathFilter, namespaces);
+
+                MetadataSchemaOperationFilter authenticatedFilter = mds.getOperationFilter(MetadataSchemaOperation.authenticated);
+                if (authenticatedFilter != null) {
+                    boolean isAuthenticated = context.getUserSession().isAuthenticated();
+                    if (!isAuthenticated) {
+                        removeFilteredElement(metadataXml, authenticatedFilter, namespaces);
                     }
                 }
-                Pair<String, Element> dynamicXpathFilter = mds.getOperationFilter(ReservedOperation.dynamic);
-                if (dynamicXpathFilter != null) {
+
+                MetadataSchemaOperationFilter downloadFilter = mds.getOperationFilter(MetadataSchemaOperation.download);
+                if (downloadFilter != null) {
+                    boolean canDownload = accessManager.canDownload(context, id);
+                    if (!canDownload) {
+                        removeFilteredElement(metadataXml, downloadFilter, namespaces);
+                    }
+                }
+                MetadataSchemaOperationFilter dynamicFilter = mds.getOperationFilter(MetadataSchemaOperation.dynamic);
+                if (dynamicFilter != null) {
                     boolean canDynamic = accessManager.canDynamic(context, id);
                     if (!canDynamic) {
-                        removeFilteredElement(metadataXml, dynamicXpathFilter, namespaces);
+                        removeFilteredElement(metadataXml, dynamicFilter, namespaces);
                     }
                 }
             }
             if (filterEditOperationElements || (getThreadLocal(false) != null && getThreadLocal(false).forceFilterEditOperation)) {
-                removeFilteredElement(metadataXml, editXpathFilter, namespaces);
+                removeFilteredElement(metadataXml, editFilter, namespaces);
             }
         }
         return metadataXml;
@@ -243,7 +258,7 @@ public abstract class XmlSerializer {
         IMetadataManager _metadataManager = ApplicationContextHolder.get().getBean(IMetadataManager.class);
         IMetadataUtils metadataUtils = ApplicationContextHolder.get().getBean(IMetadataUtils.class);
 
-        int metadataId = Integer.valueOf(id);
+        int metadataId = Integer.parseInt(id);
         AbstractMetadata md = metadataUtils.findOne(metadataId);
 
         md.setDataAndFixCR(xml);

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -1,25 +1,25 @@
-//=============================================================================
-//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel.datamanager.base;
 
@@ -43,6 +43,8 @@ import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.XmlSerializer;
 import org.fao.geonet.kernel.datamanager.*;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperation;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.search.index.IndexingList;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
@@ -141,8 +143,8 @@ public class BaseMetadataUtils implements IMetadataUtils {
         final AbstractMetadata metadata = findOne(metadataId);
         if (metadata != null && metadata.getDataInfo().getType() == MetadataType.METADATA) {
             MetadataSchema mds = schemaManager.getSchema(metadata.getDataInfo().getSchemaId());
-            Pair<String, Element> editXpathFilter = mds.getOperationFilter(ReservedOperation.editing);
-            XmlSerializer.removeFilteredElement(md, editXpathFilter, mds.getNamespaces());
+            MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(MetadataSchemaOperation.editing);
+            XmlSerializer.removeFilteredElement(md, editFilter, mds.getNamespaces());
 
             String uuid = getMetadataUuid(metadataId);
             metadataNotifierManager.updateMetadata(md, metadataId, uuid, getServiceContext());

--- a/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -23,17 +23,11 @@
 
 package org.fao.geonet.kernel.mef;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
+import jeeves.server.context.ServiceContext;
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkExtension;
@@ -44,7 +38,12 @@ import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * An extension point called to create files to export as part of the MEF export.
@@ -72,7 +71,7 @@ public class ExportFormat implements GeonetworkExtension {
                 String outputFileName = entry.getValue();
                 Path path = metadataSchema.getSchemaDir().resolve(xslFileName);
                 if (Files.isRegularFile(path)) {
-                    String outputData = formatData(metadata, true, path);
+                    String outputData = formatData(context, metadata, true, path);
                     allExports.add(Pair.read(outputFileName, outputData));
                 } else {
                     // A conversion that does not exist
@@ -96,10 +95,9 @@ public class ExportFormat implements GeonetworkExtension {
      *
      * @return ByteArrayInputStream
      */
-    public static String formatData(AbstractMetadata metadata, boolean transform, Path stylePath) throws Exception {
-        String xmlData = metadata.getData();
-
-        Element md = Xml.loadString(xmlData, false);
+    public static String formatData(ServiceContext context, AbstractMetadata metadata, boolean transform, Path stylePath) throws Exception {
+        Element md = context.getBean(DataManager.class).getMetadata(context, metadata.getId() + "", false, false, true);
+        md.removeChild("info", Edit.NAMESPACE);
 
         // Apply a stylesheet transformation when schema is ISO profil
         if (transform) {

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
@@ -1,48 +1,36 @@
-//==============================================================================
-//===
-//===   MetadataSchema
-//===
-//==============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel.schema;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Pair;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.domain.Schematron;
-import org.fao.geonet.domain.SchematronCriteria;
-import org.fao.geonet.domain.SchematronCriteriaGroup;
-import org.fao.geonet.domain.SchematronCriteriaGroupId;
-import org.fao.geonet.domain.SchematronCriteriaType;
+import org.fao.geonet.domain.*;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.schema.editorconfig.Editor;
 import org.fao.geonet.repository.SchematronCriteriaGroupRepository;
@@ -53,21 +41,16 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import java.util.*;
 
 
 //==============================================================================
@@ -81,15 +64,15 @@ public class MetadataSchema {
     private static final String XSL_FILE_EXTENSION = ".xsl";
     private static final String SCH_FILE_EXTENSION = ".sch";
     private static final String SCHEMATRON_RULE_FILE_PREFIX = "schematron-rules";
-    private Map<String, List<String>> hmElements = new HashMap<String, List<String>>();
-    private Map<String, List<List<String>>> hmRestric = new HashMap<String, List<List<String>>>();
-    private Map<String, MetadataType> hmTypes = new HashMap<String, MetadataType>();
-    private Map<String, List<String>> hmSubs = new HashMap<String, List<String>>();
-    private Map<String, String> hmSubsLink = new HashMap<String, String>();
-    private Map<String, Namespace> hmNameSpaces = new HashMap<String, Namespace>();
-    private Map<String, Namespace> hmPrefixes = new HashMap<String, Namespace>();
-    private Map<String, Pair<String, Element>> hmOperationFilters =
-        new HashMap<String, Pair<String, Element>>();
+    private Map<String, List<String>> hmElements = new HashMap<>();
+    private Map<String, List<List<String>>> hmRestric = new HashMap<>();
+    private Map<String, MetadataType> hmTypes = new HashMap<>();
+    private Map<String, List<String>> hmSubs = new HashMap<>();
+    private Map<String, String> hmSubsLink = new HashMap<>();
+    private Map<String, Namespace> hmNameSpaces = new HashMap<>();
+    private Map<String, Namespace> hmPrefixes = new HashMap<>();
+    private Map<String, MetadataSchemaOperationFilter> hmOperationFilters =
+        new HashMap<>();
     private String schemaName;
     private Path schemaDir;
     private String standardUrl;
@@ -520,7 +503,7 @@ public class MetadataSchema {
         this.schemaRepo.save(updated);
     }
 
-    public void setOperationFilters(Map<String, Pair<String, Element>> operationFilters) {
+    public void setOperationFilters(Map<String, MetadataSchemaOperationFilter> operationFilters) {
         this.hmOperationFilters = operationFilters;
     }
 
@@ -529,7 +512,7 @@ public class MetadataSchema {
      *
      * @return The XPath to select element to filter or null
      */
-    public Pair<String, Element> getOperationFilter(ReservedOperation operation) {
+    public MetadataSchemaOperationFilter getOperationFilter(MetadataSchemaOperation operation) {
         return hmOperationFilters.get(operation.name());
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperation.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.schema;
+
+public enum MetadataSchemaOperation {
+    authenticated,
+    editing,
+    download,
+    dynamic
+}

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperationFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperationFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.schema;
+
+import org.jdom.Element;
+
+public class MetadataSchemaOperationFilter {
+    private final String xpath;
+    private final String ifNotOperation;
+    private final Element markedElement;
+
+    public MetadataSchemaOperationFilter(String xpath, String ifNotOperation, Element markedElement) {
+        this.xpath = xpath;
+        this.ifNotOperation = ifNotOperation;
+        this.markedElement = markedElement;
+
+    }
+
+    public String getXpath() {
+        return xpath;
+    }
+
+    public String getIfNotOperation() {
+        return ifNotOperation;
+    }
+
+    public Element getMarkedElement() {
+        return markedElement;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -1,31 +1,34 @@
-//==============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel.search;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperation;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.WKTReader;
 import jeeves.constants.Jeeves;
@@ -105,7 +108,6 @@ import org.fao.geonet.kernel.search.lucenequeries.DateRangeQuery;
 import org.fao.geonet.kernel.search.spatial.SpatialFilter;
 import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.languages.LanguageDetector;
-import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.SourceRepository;
 import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
@@ -116,7 +118,7 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.data.jpa.domain.Specification;
 
 import javax.annotation.Nonnull;
@@ -147,6 +149,12 @@ import java.util.Set;
  */
 public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelector {
     private static Logger LOGGER = LoggerFactory.getLogger(Geonet.SEARCH_ENGINE);
+
+    // Pattern added at the end of a Lucene field to indicate that the value should be withheld
+    private static String WITHHELD_INDEX_VALUE = "|nilReasonWithheld";
+
+    private static String WITHHELD_VALUE = "withheld";
+
     private SearchManager _sm;
     private String _styleSheetName;
 
@@ -821,7 +829,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         addElement(info, Edit.Info.Elem.CHANGE_DATE, changeDate);
         addElement(info, Edit.Info.Elem.SOURCE, source);
 
-        HashSet<String> addedTranslation = new LinkedHashSet<String>();
+        HashSet<String> addedTranslation = new LinkedHashSet<>();
         if ((dumpAllField || dumpFields != null) && searchLang != null && multiLangSearchTerm != null) {
             // get the translated fields and dump those instead of the non-translated
             for (String fieldName : multiLangSearchTerm) {
@@ -831,7 +839,14 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
                         String stringValue = f.stringValue();
                         if (!stringValue.trim().isEmpty()) {
                             addedTranslation.add(fieldName);
-                            md.addContent(new Element(dumpFields.get(fieldName)).setText(stringValue));
+
+                            boolean hasWithheld = stringValue.endsWith(WITHHELD_INDEX_VALUE);
+                            if (hasWithheld) {
+                                stringValue = stringValue.replace(WITHHELD_INDEX_VALUE, "");
+                                md.addContent(new Element(fieldName).setAttribute("nilReason", WITHHELD_VALUE).setText(stringValue));
+                            } else {
+                                md.addContent(new Element(dumpFields.get(fieldName)).setText(stringValue));
+                            }
                         }
                     }
                 }
@@ -869,12 +884,131 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
                 if (fieldName.equals("_cat")) {
                     addElement(info, Edit.Info.Elem.CATEGORY, fieldValue);
                 } else if (dumpAllField && (addedTranslation == null || !addedTranslation.contains(fieldName))) {
-                    // And all other field to the root element in dump all mode
-                    md.addContent(new Element(fieldName).setText(fieldValue));
+                    boolean hasWithheld = fieldValue.endsWith(WITHHELD_INDEX_VALUE);
+                    if (hasWithheld) {
+                        fieldValue = fieldValue.replace(WITHHELD_INDEX_VALUE, "");
+
+                        // And all other field to the root element in dump all mode
+                        md.addContent(new Element(fieldName).setAttribute("nilReason", WITHHELD_VALUE).setText(fieldValue));
+                    } else {
+                        // And all other field to the root element in dump all mode
+                        md.addContent(new Element(fieldName).setText(fieldValue));
+                    }
                 }
             }
         }
         md.addContent(info);
+
+        return md;
+    }
+
+    /**
+     * Remove hidden elements from the response.
+     *
+     * Supports only elements containing withheld.
+     *
+     * To withheld a field value add to the end of the field value the text |nilReasonWithheld
+     * in the indexing file of the metadata schema:
+     *
+     * For example to withheld metadata contact information:
+     *
+     *  <xsl:variable name="withheld"
+     *                   select="if ($type = 'metadata')
+     *                           then '|nilReasonWithheld'
+     *                           else ''" />
+     *
+     *
+     *  <Field name="{$fieldPrefix}"
+     *            string="{concat($roleTranslation, '|',
+     *                            $type, '|',
+     *                            $orgName, '|',
+     *                            $logo, '|',
+     *                            string-join($email, ','), '|',
+     *                            string-join($individualNames, ','), '|',
+     *                            string-join($positionName, ','), '|',
+     *                            $address, '|',
+     *                            string-join($phones, ','), '|',
+     *                            $uuid, '|',
+     *                            $position, '|',
+     *                            $website, $withheld)}"
+     *            store="true" index="false"/>
+     *
+     * @param context
+     * @param md
+     * @param schema
+     * @return
+     */
+    private static Element removeHiddenElements(ServiceContext context, Element md, String schema) {
+        try {
+            List<?> nodes = Xml.selectNodes(md,
+                "*[@nilReason]", new ArrayList<>());
+
+            if (!nodes.isEmpty()) {
+                Element info = md.getChild(Edit.RootChild.INFO, Edit.NAMESPACE);
+
+                boolean cleanNilReasonAttributes = true;
+
+                if (context != null) {
+                    MetadataSchema mds = context.getBean(DataManager.class).getSchema(schema);
+
+                    MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(MetadataSchemaOperation.editing);
+                    boolean filterEditOperationElements = false;
+
+                    if (editFilter != null && editFilter.getXpath().contains(WITHHELD_VALUE)) {
+                        boolean canEdit = (Boolean.TRUE.toString().equals(info.getChildText(Edit.Info.Elem.EDIT)));
+                        filterEditOperationElements = !canEdit;
+                    }
+
+                    MetadataSchemaOperationFilter authenticatedFilter = mds.getOperationFilter(MetadataSchemaOperation.authenticated);
+                    boolean filterAuthOperationElements = false;
+                    if (authenticatedFilter != null && authenticatedFilter.getXpath().contains(WITHHELD_VALUE)) {
+                        boolean isAuthenticated = context.getUserSession().isAuthenticated();
+                        filterAuthOperationElements = !isAuthenticated;
+                    }
+
+                    MetadataSchemaOperationFilter downloadFilter = mds.getOperationFilter(MetadataSchemaOperation.download);
+                    boolean filterDownloadOperationElements = false;
+                    if (downloadFilter != null && downloadFilter.getXpath().contains(WITHHELD_VALUE)) {
+                        boolean canDownload = (Boolean.TRUE.toString().equals(info.getChildText(Edit.Info.Elem.DOWNLOAD)));
+                        filterDownloadOperationElements = !canDownload;
+                    }
+                    MetadataSchemaOperationFilter dynamicFilter = mds.getOperationFilter(MetadataSchemaOperation.dynamic);
+                    boolean filterDynamicOperationElements = false;
+                    if (dynamicFilter != null && dynamicFilter.getXpath().contains(WITHHELD_VALUE)) {
+                        boolean canDynamic = (Boolean.TRUE.toString().equals(info.getChildText(Edit.Info.Elem.DYNAMIC)));
+                        if (!canDynamic) {
+                            filterDynamicOperationElements = true;
+                        }
+                    }
+
+                    if (filterEditOperationElements || filterAuthOperationElements ||
+                        filterDownloadOperationElements || filterDynamicOperationElements) {
+                        // No need to cleanup the nilReason attributes, as the elements are removed
+                        cleanNilReasonAttributes = false;
+
+                        for (Object object : nodes) {
+                            if (object instanceof Element) {
+                                Element element = (Element) object;
+                                md.removeContent(element);
+                            }
+                        }
+                    }
+                }
+
+                if (cleanNilReasonAttributes) {
+                    // Cleanup nilReason attribute from the result
+                    for (Object object : nodes) {
+                        if (object instanceof Element) {
+                            Element element = (Element) object;
+                            element.removeAttribute("nilReason");
+                        }
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            LOGGER.error(ex.getMessage(), ex);
+        }
+
         return md;
     }
 
@@ -890,7 +1024,13 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         f) {
         if (f != null) {
             if (addedTranslation == null || !addedTranslation.contains(fieldName)) {
-                md.addContent(new Element(outputName).setText(f.stringValue()));
+                boolean hasWithheld = f.stringValue().endsWith(WITHHELD_INDEX_VALUE);
+
+                if (!hasWithheld) {
+                    md.addContent(new Element(outputName).setText(f.stringValue()));
+                } else {
+                     md.addContent(new Element(outputName).setAttribute("nilReason", "withheld").setText(f.stringValue().replace("|withheld", "")));
+                }
             }
         }
     }
@@ -1246,6 +1386,9 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
                         //--- search results
 
                         if (md != null) {
+                            // Remove withheld elements
+                            md = removeHiddenElements(srvContext, md, doc.get(Geonet.IndexFieldNames.SCHEMA));
+
                             // Calculate score and add it to info elem
                             if (_luceneConfig.isTrackDocScores()) {
                                 Float score = tdocs.scoreDocs[i].score;

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
@@ -288,19 +288,19 @@
           <xsl:copy-of select="gn-fn-iso19115-3.2018:index-field('projectid', ., $langId)"/>
           <xsl:copy-of select="gn-fn-iso19115-3.2018:index-field('databaseid', ., $langId, true(), true())"/>
         </xsl:for-each>
- 
+
         <!-- Add vsdl schema as a separate field -->
         <xsl:for-each select="cit:identifier/mcc:MD_Identifier[contains(mcc:description/gco:CharacterString,'VSDL')]/mcc:code">
           <xsl:copy-of select="gn-fn-iso19115-3.2018:index-field('vsdlschema', ., $langId)"/>
         </xsl:for-each>
- 
+
         <!-- Add metashare jurisdiction as a separate field -->
         <xsl:for-each select="cit:identifier/mcc:MD_Identifier[contains(mcc:description/gco:CharacterString,'Jurisdiction')]/mcc:code">
           <xsl:copy-of select="gn-fn-iso19115-3.2018:index-field('jurisdiction', ., $langId)"/>
         </xsl:for-each>
 
-         <!-- Add DELWP resource owner - selects org of first owner, because some have additional owner  -->                      
-        <xsl:for-each select="cit:citedResponsibleParty[cit:CI_Responsibility/cit:role/cit:CI_RoleCode/@codeListValue = 'owner']/cit:CI_Responsibility/cit:party/cit:CI_Organisation/cit:name">  
+         <!-- Add DELWP resource owner - selects org of first owner, because some have additional owner  -->
+        <xsl:for-each select="cit:citedResponsibleParty[cit:CI_Responsibility/cit:role/cit:CI_RoleCode/@codeListValue = 'owner']/cit:CI_Responsibility/cit:party/cit:CI_Organisation/cit:name">
           <xsl:copy-of select="gn-fn-iso19115-3.2018:index-field('resOwner', ., $langId, true(), true())"/>
         </xsl:for-each>
         <!-- END DELWP Addition -->
@@ -679,7 +679,7 @@
 
         <!-- DELWP Addition -->
         <!-- Add separate field for DELWP res constraints - not indexed -->
-        <xsl:for-each select="mco:classification">                                                     
+        <xsl:for-each select="mco:classification">
           <xsl:copy-of select="gn-fn-iso19115-3.2018:index-field('resClassification', mco:MD_ClassificationCode/@codeListValue, $langId
 , true(), false())"/>
         </xsl:for-each>
@@ -720,9 +720,9 @@
     </xsl:for-each>
 
     <!-- DELWP Addition -->
-    <!-- Add DELWP grid resolution -->                                                                             
-    <xsl:for-each select="$metadata/mdb:spatialRepresentationInfo//msr:MD_Dimension">                                                                                     
-      
+    <!-- Add DELWP grid resolution -->
+    <xsl:for-each select="$metadata/mdb:spatialRepresentationInfo//msr:MD_Dimension">
+
       <xsl:choose>
         <!-- handle row resolution -->
         <xsl:when test="msr:dimensionName/msr:MD_DimensionNameTypeCode/@codeListValue = 'row'">
@@ -745,7 +745,7 @@
           <!-- <xsl:copy-of select="gn-fn-iso19115-3.2018:index-field('columnResolution', $columnResolution, $langId, true(), true())"/> -->
         </xsl:when>
       </xsl:choose>
-    </xsl:for-each>   
+    </xsl:for-each>
 
     <!-- Add DELWP LiDAR fields to index -->
     <xsl:for-each select="$metadata/mdb:acquisitionInformation//delwp:MD_PointCloudDetails">
@@ -754,7 +754,7 @@
       <xsl:variable name="footprintVal" select="string(delwp:footprintSize/*)"/>
       <xsl:variable name="footprintUom" select="string(delwp:footprintSize/*/@uom)"/>
       <Field name="footprintSize" string="{concat($footprintVal, $footprintUom)}" store="true" index="false"/>
-      
+
       <!-- get pointDensityTarget -->
       <xsl:variable name="pointDensityTargetVal" select="string(delwp:pointDensityTarget/*)"/>
       <xsl:variable name="pointDensityTargetUom" select="string(delwp:pointDensityTarget/*/@uom)"/>
@@ -775,14 +775,14 @@
       <xsl:variable name="pointSpacingActualUom" select="string(delwp:pointSpacingActual/*/@uom)"/>
       <Field name="pointSpacingActual" string="{concat($pointSpacingActualVal, $pointSpacingActualUom)}" store="true" index="false"/>
 
-    </xsl:for-each> 
-    
-    <!-- Add DELWP metadata constraints - not indexed -->                                                                                           
-    <xsl:for-each select="$metadata/mdb:metadataConstraints/*">                                                                                     
-      <xsl:for-each select="mco:classification">                                                                                                    
+    </xsl:for-each>
+
+    <!-- Add DELWP metadata constraints - not indexed -->
+    <xsl:for-each select="$metadata/mdb:metadataConstraints/*">
+      <xsl:for-each select="mco:classification">
         <xsl:copy-of select="gn-fn-iso19115-3.2018:index-field('mdClassification', mco:MD_ClassificationCode/@codeListValue, $langId, true(), true())"/>
-      </xsl:for-each>                                                                                                                               
-    </xsl:for-each>    
+      </xsl:for-each>
+    </xsl:for-each>
     <!-- END DELWP Addition -->
 
     <xsl:for-each select="$metadata/mdb:distributionInfo/mrd:MD_Distribution">
@@ -940,11 +940,11 @@
         <xsl:if test="count($attributes) > 0">
           "attributeTable" : [
           <xsl:for-each select="$attributes">
-            {"name": "<xsl:apply-templates mode="localised" 
-                  select="*/gfc:memberName"><xsl:with-param name="langId" 
+            {"name": "<xsl:apply-templates mode="localised"
+                  select="*/gfc:memberName"><xsl:with-param name="langId"
                   select="concat('#', $langId)"/></xsl:apply-templates>",
-            "definition": "<xsl:apply-templates mode="localised" 
-                  select="*/gfc:definition"><xsl:with-param name="langId" 
+            "definition": "<xsl:apply-templates mode="localised"
+                  select="*/gfc:definition"><xsl:with-param name="langId"
                   select="concat('#', $langId)"/></xsl:apply-templates>",
             "code": "<xsl:value-of select="*/gfc:code/*/text()"/>",
             "link": "<xsl:value-of select="*/gfc:code/*/@xlink:href"/>",
@@ -952,12 +952,12 @@
             <xsl:if test="*/gfc:listedValue">
               ,"values": [
               <xsl:for-each select="*/gfc:listedValue">{
-                "label": "<xsl:apply-templates mode="localised" 
-                  select="*/gfc:label"><xsl:with-param name="langId" 
+                "label": "<xsl:apply-templates mode="localised"
+                  select="*/gfc:label"><xsl:with-param name="langId"
                   select="concat('#', $langId)"/></xsl:apply-templates>",
                 "code": "<xsl:value-of select="*/gfc:code/*/text()"/>",
-                "definition": "<xsl:apply-templates mode="localised" 
-                  select="*/gfc:definition"><xsl:with-param name="langId" 
+                "definition": "<xsl:apply-templates mode="localised"
+                  select="*/gfc:definition"><xsl:with-param name="langId"
                   select="concat('#', $langId)"/></xsl:apply-templates>"
                 }
                 <xsl:if test="position() != last()">,</xsl:if>
@@ -1254,6 +1254,13 @@
            store="false"
            index="true"/>
 
+    <xsl:variable name="withheld"
+                  select="if ($type = 'metadata')
+                          then '|nilReasonWithheld'
+                          else if ($role != 'pointOfContact')
+                          then '|nilReasonWithheld'
+                          else ''" />
+
     <Field name="{$fieldPrefix}"
            string="{concat($roleTranslation, '|',
                            $type, '|',
@@ -1266,7 +1273,7 @@
                            string-join($phones, ','), '|',
                            $uuid, '|',
                            $position, '|',
-                           $website)}"
+                           $website, $withheld)}"
            store="true" index="false"/>
 
     <xsl:for-each select="$email">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
@@ -65,13 +65,13 @@ Metadata Profile of ISO19115-3 (2018) for Victorian Government Department of Env
   -->
   <filters xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
     <!--
-    All elemenets having a nilReason attribute
+    All elements having a nilReason attribute
     set to withheld, then users needs to have
     the edit privilege in order to be able to see
     the information. When filtered the element is
     preserved but with no content in.
     -->
-    <filter xpath="*//*[@gco:nilReason='withheld']"
+    <filter xpath=".//*[@gco:nilReason='withheld']"
             ifNotOperation="editing">
       <keepMarkedElement gco:nilReason="withheld"/>
     </filter>
@@ -81,7 +81,7 @@ Metadata Profile of ISO19115-3 (2018) for Victorian Government Department of Env
     are filtered when user does not have download
     privilege.
     -->
-    <filter xpath="*//mrd:onLine[contains(*/cit:protocol/gco:CharacterString, 'DOWNLOAD') or
+    <filter xpath=".//mrd:onLine[contains(*/cit:protocol/gco:CharacterString, 'DOWNLOAD') or
                                   */cit:protocol/gco:CharacterString = 'FILE' or
                                   */cit:protocol/gco:CharacterString = 'DB' or
                                   */cit:protocol/gco:CharacterString = 'COPYFILE']"
@@ -92,7 +92,7 @@ Metadata Profile of ISO19115-3 (2018) for Victorian Government Department of Env
     to user not having dynamic privilege.
     TODO: other type of services ?
     -->
-    <filter xpath="*//mrd:onLine[starts-with(*/cit:protocol/gco:CharacterString, 'OGC:WMS')]"
+    <filter xpath=".//mrd:onLine[starts-with(*/cit:protocol/gco:CharacterString, 'OGC:WMS')]"
             ifNotOperation="dynamic"/>
   </filters>
 </schema>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
@@ -15,7 +15,7 @@ Metadata Profile of ISO19115-3 (2018) for Victorian Government Department of Env
   <!-- FIXME: add all required schemas -->
   <schemaLocation>http://standards.iso.org/iso/19115/-3/mds/2.0 http://standards.iso.org/iso/19115/-3/mds/2.0/mds.xsd</schemaLocation>
   <autodetect xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
-              xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0" 
+              xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
               xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
               xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
               xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
@@ -72,7 +72,7 @@ Metadata Profile of ISO19115-3 (2018) for Victorian Government Department of Env
     preserved but with no content in.
     -->
     <filter xpath=".//*[@gco:nilReason='withheld']"
-            ifNotOperation="editing">
+            ifNotOperation="authenticated">
       <keepMarkedElement gco:nilReason="withheld"/>
     </filter>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -18,6 +18,8 @@
   xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
   xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
   xmlns:delwp="https://github.com/geonetwork-delwp/iso19115-3.2018"
+  xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
+  xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:gn-fn-iso19115-3.2018="http://geonetwork-opensource.org/xsl/functions/profiles/iso19115-3.2018"
   xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -116,10 +118,10 @@
             </cit:CI_Responsibility>
           </mdb:contact>
         </xsl:when>
-        <!-- Add current user as processor, then process everything except the 
+        <!-- Add current user as processor, then process everything except the
              existing processor which will be excluded from the output
              document - this is to ensure that only the latest user is
-             added as a processor - note: Marlin administrator is excluded from 
+             added as a processor - note: Marlin administrator is excluded from
              this role -->
         <xsl:otherwise>
           <xsl:choose>
@@ -133,7 +135,7 @@
                   <xsl:call-template name="addCurrentUserAsParty"/>
                 </cit:CI_Responsibility>
               </mdb:contact>
-              <!-- copy any other metadata contacts with the exception of processors and 
+              <!-- copy any other metadata contacts with the exception of processors and
                    pointOfContact so we make sure that IDC is point of contact -->
               <xsl:apply-templates select="mdb:contact[not(cit:CI_Responsibility/cit:role/cit:CI_RoleCode='processor' or cit:CI_Responsibility/cit:role/cit:CI_RoleCode='pointOfContact')]"/>
             </xsl:when>
@@ -817,6 +819,25 @@
     </xsl:if>
   </xsl:template>
 
+  <!-- Withheld mdb:contact, cit:citedResponsibleParty, mrd:distributorContact elements -->
+  <xsl:template match="mdb:contact|cit:citedResponsibleParty|mrd:distributorContact|mco:responsibleParty|mmi:contact" priority="10">
+    <xsl:copy>
+      <xsl:copy-of select="@*[name() != 'gco:nilReason']" />
+      <xsl:attribute name="gco:nilReason">withheld</xsl:attribute>
+
+      <xsl:apply-templates select="*" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Withheld mri:pointOfContact elements with a role different than pointOfContact -->
+  <xsl:template match="mri:pointOfContact[*/cit:role/cit:CI_RoleCode/@codeListValue != 'pointOfContact']" priority="10">
+    <xsl:copy>
+      <xsl:copy-of select="@*[name() != 'gco:nilReason']" />
+      <xsl:attribute name="gco:nilReason">withheld</xsl:attribute>
+
+      <xsl:apply-templates select="*" />
+    </xsl:copy>
+  </xsl:template>
 
 
   <!-- Remove empty DQ elements, empty transfer options, empty lineage -->

--- a/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
@@ -84,12 +84,12 @@
     </elements>
   </autodetect>
   <filters xmlns:gco="http://www.isotc211.org/2005/gco">
-    <filter xpath="*//*[@gco:nilReason='withheld']"
+    <filter xpath=".//*[@gco:nilReason='withheld']"
             ifNotOperation="editing">
       <keepMarkedElement gco:nilReason="withheld"/>
     </filter>
     <filter
-      xpath="*//gmd:onLine[*/gmd:protocol/gco:CharacterString = 'WWW:DOWNLOAD-1.0-http--download']"
+      xpath=".//gmd:onLine[*/gmd:protocol/gco:CharacterString = 'WWW:DOWNLOAD-1.0-http--download']"
       ifNotOperation="download"/>
     <filter xpath="*//gmd:onLine[starts-with(*/gmd:protocol/gco:CharacterString, 'OGC:WMS')]"
             ifNotOperation="dynamic"/>

--- a/web/src/main/filters/prod.properties
+++ b/web/src/main/filters/prod.properties
@@ -21,7 +21,7 @@
 # Rome - Italy. email: geonetwork@osgeo.org
 #
 
-stagingProfile=production
+stagingProfile=development
 
 # indicate how often the wro4j caches should be updated
 # 0 is never, otherwise it is the number of seconds between updates

--- a/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
+++ b/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
@@ -258,6 +258,7 @@
           <xs:enumeration value="editing"/>
           <xs:enumeration value="download"/>
           <xs:enumeration value="dynamic"/>
+          <xs:enumeration value="authenticated" />
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>


### PR DESCRIPTION
This pull request contains the following changes:

- https://github.com/geonetwork/core-geonetwork/pull/6897 to support the withheld information from the metadata XML to hide the metadata elements anonymised from the Lucene query responses.
- Specific changes to anonymise the DEECA contacts: e24243d4b883851c00ada51e8930dca37f0c8c84 and prevent to view this information to anonymous users.
- Specific change to disable the full formatter caching, otherwise are created static html pages, so if an authenticated user access a full formatter, that version is cached and provided to all users: df970223d048f88f3de67d1120f2f7e297cf15eb

  This configuration is displayed in the Settings page. Despite of an unfortunate name, it only affects to the metadata formatters, should be kept with the value `Development`:


  ![settings](https://user-images.githubusercontent.com/1695003/225842420-cb175b36-4f7e-461d-a45e-a717e51ab252.png)
