### PR TITLE
Display metadata footprints in metadata full view

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/BoundingDirective.js
@@ -74,6 +74,7 @@
 
             // set read only
             ctrl.readOnly = $scope.$eval($attrs['readOnly']);
+            ctrl.viewerOnly = $scope.$eval($attrs['viewerOnly']) || false;
 
             // init map
             ctrl.map = gnMapsManager.createMap(gnMapsManager.EDITOR_MAP);

--- a/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
+++ b/web-ui/src/main/resources/catalog/components/edit/bounding/partials/boundingpolygon.html
@@ -31,7 +31,7 @@
       </button>
     </div>
   </div>
-  <div class="col-xs-12 col-sm-6 col-sm-pull-6">
+  <div class="col-xs-12 col-sm-6 col-sm-pull-6" data-ng-if="!ctrl.viewerOnly">
     <label class="text-muted control-label" translate>
       selectFormatAndProjection</label>
     <br />
@@ -62,7 +62,7 @@
 </div>
 
 <!-- input geometry field -->
-<div class="row">
+<div class="row" data-ng-if="!ctrl.viewerOnly">
   <div class="col-md-12">
     <div class="has-feedback"
          ng-class="{ 'has-success': ctrl.fromTextInput && !ctrl.parseError, 'has-error': ctrl.parseError }">

--- a/web-ui/src/main/resources/catalog/js/GnSearchModule.js
+++ b/web-ui/src/main/resources/catalog/js/GnSearchModule.js
@@ -28,6 +28,7 @@
   goog.require('gn_formatter_lib');
   goog.require('gn_map_field_directive');
   goog.require('gn_field_duration_directive');
+  goog.require('gn_bounding_directive');
   goog.require('gn_mdactions');
   goog.require('gn_mdview');
   goog.require('gn_module');
@@ -40,6 +41,7 @@
     'gn_resultsview',
     'gn_map_field_directive',
     'gn_field_duration_directive',
+    'gn_bounding_directive',
     'gn_search_controller',
     'gn_viewer',
     'gn_mdview',


### PR DESCRIPTION
This change displays in the metadata full view the metadata polygon footprints. Previously the were not displayed.

Before:

![metadata-footprints-1](https://user-images.githubusercontent.com/1695003/235956277-6da19e08-81ef-4716-a413-0051813d2399.png)

After:

![metadata-footprints-2](https://user-images.githubusercontent.com/1695003/235956292-09fe64bb-e4af-42c5-9cf3-3fa86432d706.png)

