### PR TITLE
Metadata editor / check duplicated metadata resource name

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -81,6 +81,16 @@
     <for name="delwp:environmentalConditions" use="textarea"/>
     <for name="delwp:tidalConditions" use="textarea"/>
 
+    <!-- DELWP Additions -->
+    <!-- Check if resource name (cit:alternateTitle) is defined in other metadata record -->
+    <for name="cit:alternateTitle"
+         xpath="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:alternateTitle"
+         use="data-gn-duplicated-metadata-value-checker">
+      <directiveAttributes
+        data-field-name="ResourceName"
+        data-field-index-key="altTitle" />
+    </for>
+
     <for name="gco:Distance" use="number"/>
     <for name="gco:Decimal" use="number"/>
     <for name="gco:Integer" use="number"/>

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -422,5 +422,6 @@
     "draft": "Working copy",
     "link": "Link",
     "link-text": "Link text",
-    "confirmCancelEdit": "Do you want to cancel all changes and close the editor?"
+    "confirmCancelEdit": "Do you want to cancel all changes and close the editor?",
+    "metadataDuplicatedFieldResourceName": "The value of 'Resource name' is used in another metadata record."
 }


### PR DESCRIPTION
This changes adds a check for the metadata resource name, to inform if the same resource is used in another metadata record:

![duplicated-resourcename-check](https://user-images.githubusercontent.com/1695003/237033685-4e82e629-b6dc-41fa-984b-d0437426b9bd.png)

The change allows also to configure checks for the following fields if would be required in the future:

- Metadata title.
- Resource name (metadata alternate title): current usage.
- Metadata resource identifier.